### PR TITLE
Add the ability to share and load tierlists

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/monolith.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dragula/3.7.3/dragula.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@1.6.5/dist/axios.min.js"></script>
 </head>
 <body>
     <main>
@@ -124,6 +125,9 @@
         <button type="button" onclick="selectImages()">Select images</button>
         <input type="checkbox" id="img" onchange="dynamicStyle('img')">
         <label for="img">Square images</label>
+        <button type="button" id="share" onclick="share()">Share</button>
+        <input type="checkbox" id="includepositions">
+        <label for="includepositions">Include current positions</label>
     </div>
 
     <div id="images-bar" class="sort"></div>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     scrollable = true;
+
+    load()
 });
 
 document.addEventListener("touchmove", function (event) {
@@ -185,4 +187,187 @@ function dynamicStyle(id) {
         }
     }
     style.innerHTML = content;
+}
+
+// Helper function to encode non UTF-8 characters to Base64
+function encodeUnicode(str) {
+    return btoa(
+        encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(match, p1) {
+            return String.fromCharCode('0x' + p1)
+        })
+    )
+}
+
+// Helper function to decode non UTF-8 characters from Base64
+function decodeUnicode(str) {
+    return decodeURIComponent(
+        atob(str)
+            .split('')
+            .map(function (c) {
+                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            })
+            .join('')
+    )
+}
+
+function share() {
+    const shareButton = document.getElementById("share")
+    shareButton.innerText = "..."
+
+    let shareJSON = {
+        images: [],
+        tiers: []
+    }
+
+    const tiers = document.getElementsByClassName("row")
+    const imagesBar = document.getElementById("images-bar");
+    const barImages = Array.prototype.slice.call(imagesBar.children)
+
+    for (const tier in Array.prototype.slice.call(tiers)) {
+        const betterTier = {
+            index: tier,
+            el: tiers[tier],
+            name: tiers[tier].children[0].children[0].textContent,
+            color: tiers[tier].children[0].style.backgroundColor,
+            images: Array.prototype.slice.call(tiers[tier].children[1].children)            
+        }
+
+        shareJSON.tiers.push({
+            index: betterTier.index,
+            name: betterTier.name,
+            color: betterTier.color
+        })
+            
+        console.log(betterTier)
+        const checkbox = document.getElementById("includepositions")
+
+        console.log(`Sharing with${checkbox.checked ? '' : 'out'} positions...`)
+
+        for (const img in betterTier.images) {
+            const betterImage = {
+                index: img,
+                el: betterTier.images[img],
+                src: betterTier.images[img].src
+            }
+            
+            // Convert image to DataURL
+            const c = document.createElement('canvas');
+            c.height = betterImage.el.naturalHeight;
+            c.width = betterImage.el.naturalWidth;
+            const ctx = c.getContext('2d');
+            ctx.drawImage(betterImage.el, 0, 0, c.width, c.height);
+            const base64String = c.toDataURL();
+            c.remove()
+
+            shareJSON.images.push({
+                img: base64String,
+                tier: checkbox.checked ? betterTier.index : -1
+            })
+        }
+    }
+
+    for (const img in Array.prototype.slice.call(imagesBar.children)) {
+        const betterImage = {
+            index: img,
+            el: barImages[img],
+            src: barImages[img].src
+        }
+
+        const MAX_IMG_SIZE = 500
+        
+        // Compress image and convert to DataURL
+        const c = document.createElement('canvas');
+        const ratio = betterImage.el.naturalHeight / betterImage.el.naturalWidth
+        c.height = Math.min(ratio >= 1 ? MAX_IMG_SIZE : Math.round(MAX_IMG_SIZE * ratio), betterImage.el.naturalHeight);
+        c.width = Math.min(ratio <= 1 ? MAX_IMG_SIZE : Math.round(MAX_IMG_SIZE * ratio), betterImage.el.naturalWidth);
+        const ctx = c.getContext('2d');
+        ctx.drawImage(betterImage.el, 0, 0, c.width, c.height);
+        const base64String = c.toDataURL();
+        c.remove()
+
+        shareJSON.images.push({
+            img: base64String,
+            tier: -1
+        })
+    }
+
+    const c64 = encodeUnicode(JSON.stringify(shareJSON))
+    const chunks = c64.match(/.{1,10000}/g)
+
+    Promise.all(chunks.map((chunk, idx) => {
+        return axios.post("https://corsproxy.org/?https://hastebin.skyra.pw/documents", chunk)
+    })).then((values) => {
+        const strings = values.map((v) => v.data.key)
+        axios.post("https://corsproxy.org/?https://hastebin.skyra.pw/documents", encodeUnicode(JSON.stringify(strings))).then((res) => {
+            console.dir(res)
+
+            navigator.clipboard.writeText("https://agatem.art/tier-list-creator/#" + res.data.key).then(() => {
+            shareButton.innerText = "Copied!"
+
+                setTimeout(() => {
+                    shareButton.innerText = "Share"
+                }, 10000)
+            })
+        })
+    })
+}
+
+function load() {
+    const hash = window.location.hash.substring(1);
+    console.log("Loading...")
+
+    if (hash.length <= 0) {
+        console.log("Nothing to load!")
+        return
+    }
+
+    console.log(hash)
+    axios.get("https://corsproxy.org/?https://hastebin.skyra.pw/raw/" + hash).then((res) => {
+        console.log(res.data)
+        const c = decodeUnicode(res.data)
+        console.log(c)
+        const data = JSON.parse(c)
+        console.dir(data)
+
+        Promise.all(data.map((code) => {
+            return axios.get("https://corsproxy.org/?https://hastebin.skyra.pw/raw/" + code)
+        })).then((values) => {
+            console.log(values)
+            const res = values.map((res) => {
+                return res.data
+            }).join("")
+            const c = decodeUnicode(res)
+            const data = JSON.parse(c)
+
+            for (const r of Array.prototype.slice.call(document.getElementsByClassName("row"))) {
+                deleteRow(r)
+            }
+            
+            data.tiers.forEach(() => {
+                addRow()
+            })
+
+
+    
+            for (const tier of data.tiers) {
+                const el = Array.prototype.slice.call(document.getElementsByClassName("row"))[tier.index]
+                el.children[0].children[0].textContent = tier.name
+                el.children[0].style.backgroundColor = tier.color
+            }
+            
+            const imagesBar = document.getElementById("images-bar")
+
+            for (const img of data.images) {
+                const image = document.createElement("img");
+                image.src = img.img;
+                image.className = "image";
+                
+                if (img.tier == -1) {
+                    imagesBar.appendChild(image);
+                } else {
+                    document.getElementsByClassName("row")[img.tier].children[1].appendChild(image)
+                }
+            }
+        })
+    })
 }


### PR DESCRIPTION
This PR adds the ability to be able to share Tierlists. Features:
* Ability to share tierlists with (basically) unlimited images
* Images are compressed with a max-side-size ratio-preservant algorithm (using JS Canvas)
* Tierlists can be shared maintaining the images' position (optionally, there's a checkbox to enable it)
* Tierlists are shared to a single-hash-link (e.g. `https://domain.com/#hash`)
* Completely serverless (no database needed!)
* Opening the hash-link loads the Tierlist automatically
* The single-hash-link is automatically copied to the keyboard